### PR TITLE
feat: Use chrono::TimeDelta to support signed time in physics ops

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zmatrix"
-version = "0.2.29"
+version = "0.3.0"
 edition = "2021"
 authors = ["Treagzhao"]
 license = "MIT"
@@ -9,6 +9,7 @@ description = "This is a matrix calculation lib"
 
 [dependencies]
 approx = "0.5.1"
+chrono = "0.4"
 array-init = "2.1.0"
 criterion = { version = "0.6.0"}
 lazy_static = "1.5.0"

--- a/examples/example_new_operations.rs
+++ b/examples/example_new_operations.rs
@@ -25,16 +25,16 @@ fn main() {
     let velocity = Velocity::from_m_per_sec(20.0); // 20 m/s
     let acceleration = Acceleration::from_m_per_s2(4.0); // 4 m/s²
     let time = velocity / acceleration; // 5 s
-    println!("   20 m/s ÷ 4 m/s² = {} s", time.as_secs_f64());
-    println!("   验证: 4 m/s² × {} s = {} m/s\n", time.as_secs_f64(), (acceleration * time).as_m_per_sec());
+    println!("   20 m/s ÷ 4 m/s² = {} s", time_delta_to_secs_f64(&time));
+    println!("   验证: 4 m/s² × {} s = {} m/s\n", time_delta_to_secs_f64(&time), (acceleration * time).as_m_per_sec());
 
     // 4. 距离 ÷ 速度 = 时间
     println!("4. 距离 ÷ 速度 = 时间");
     let distance = Distance::from_m(200.0); // 200 m
     let velocity = Velocity::from_m_per_sec(25.0); // 25 m/s
     let time = distance / velocity; // 8 s
-    println!("   200 m ÷ 25 m/s = {} s", time.as_secs_f64());
-    println!("   验证: 25 m/s × {} s = {} m\n", time.as_secs_f64(), (velocity * time).as_m());
+    println!("   200 m ÷ 25 m/s = {} s", time_delta_to_secs_f64(&time));
+    println!("   验证: 25 m/s × {} s = {} m\n", time_delta_to_secs_f64(&time), (velocity * time).as_m());
 
     // 5. 功率 ÷ 力 = 速度
     println!("5. 功率 ÷ 力 = 速度");
@@ -57,8 +57,8 @@ fn main() {
     let omega = AngularVelocity::from_rad_per_second(12.0); // 12 rad/s
     let alpha = AngularAcceleration::from_rad_per_second2(3.0); // 3 rad/s²
     let time = omega / alpha; // 4 s
-    println!("   12 rad/s ÷ 3 rad/s² = {} s", time.as_secs_f64());
-    println!("   验证: 3 rad/s² × {} s = {} rad/s\n", time.as_secs_f64(), (alpha * time).as_rad_per_second());
+    println!("   12 rad/s ÷ 3 rad/s² = {} s", time_delta_to_secs_f64(&time));
+    println!("   验证: 3 rad/s² × {} s = {} rad/s\n", time_delta_to_secs_f64(&time), (alpha * time).as_rad_per_second());
 
     // 实际应用示例
     println!("=== 实际应用示例 ===");
@@ -71,7 +71,7 @@ fn main() {
     let braking_distance = initial_velocity * braking_time; // 制动距离
     println!("   初始速度: {} km/h", initial_velocity.as_km_per_h());
     println!("   减速度: {} m/s²", deceleration.as_m_per_s2());
-    println!("   制动时间: {:.2} s", braking_time.as_secs_f64());
+    println!("   制动时间: {:.2} s", time_delta_to_secs_f64(&braking_time));
     println!("   制动距离: {:.2} m", braking_distance.as_m());
 
     // 电机功率计算

--- a/src/dense/shape.rs
+++ b/src/dense/shape.rs
@@ -237,7 +237,7 @@ mod tests {
         let m = Matrix::<0, 0, f64>::new([[]; 0]);
         let result = m.sum_column();
         assert_eq!(result.size(), (1, 0));
-        assert_eq!(result.data, [[]]);
+        assert_eq!(result.data, [[] as [f64; 0]; 1]);
     }
 
     #[test]

--- a/src/physics/basic.rs
+++ b/src/physics/basic.rs
@@ -605,6 +605,18 @@ impl<T: VectorQuantity + Default> Default for Vector3<T> {
         }
     }
 }
+
+/// 从 f64 秒数创建 chrono::TimeDelta（支持负数）
+pub fn time_delta_from_secs_f64(secs: f64) -> chrono::TimeDelta {
+    let nanos = (secs * 1_000_000_000.0) as i64;
+    chrono::TimeDelta::nanoseconds(nanos)
+}
+
+/// 将 chrono::TimeDelta 转换为 f64 秒数
+pub fn time_delta_to_secs_f64(td: &chrono::TimeDelta) -> f64 {
+    td.num_seconds() as f64 + td.subsec_nanos() as f64 * 1e-9
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/physics/basic/acceleration.rs
+++ b/src/physics/basic/acceleration.rs
@@ -64,6 +64,14 @@ impl Mul<Duration> for Acceleration {
     }
 }
 
+impl Mul<chrono::TimeDelta> for Acceleration {
+    type Output = Velocity;
+    fn mul(self, rhs: chrono::TimeDelta) -> Self::Output {
+        let v = self.as_m_per_s2() * time_delta_to_secs_f64(&rhs);
+        Velocity::from_m_per_sec(v)
+    }
+}
+
 // 引用版本：Acceleration * Duration -> Velocity
 impl<'a> Mul<Duration> for &'a Acceleration {
     type Output = Velocity;
@@ -76,6 +84,20 @@ impl<'a> Mul<&'a Duration> for Acceleration {
 impl<'a, 'b> Mul<&'b Duration> for &'a Acceleration {
     type Output = Velocity;
     fn mul(self, rhs: &'b Duration) -> Self::Output { Velocity::from_m_per_sec(self.as_m_per_s2() * rhs.as_secs_f64()) }
+}
+
+// 引用版本：Acceleration * TimeDelta -> Velocity
+impl<'a> Mul<chrono::TimeDelta> for &'a Acceleration {
+    type Output = Velocity;
+    fn mul(self, rhs: chrono::TimeDelta) -> Self::Output { Velocity::from_m_per_sec(self.as_m_per_s2() * time_delta_to_secs_f64(&rhs)) }
+}
+impl<'a> Mul<&'a chrono::TimeDelta> for Acceleration {
+    type Output = Velocity;
+    fn mul(self, rhs: &'a chrono::TimeDelta) -> Self::Output { Velocity::from_m_per_sec(self.as_m_per_s2() * time_delta_to_secs_f64(rhs)) }
+}
+impl<'a, 'b> Mul<&'b chrono::TimeDelta> for &'a Acceleration {
+    type Output = Velocity;
+    fn mul(self, rhs: &'b chrono::TimeDelta) -> Self::Output { Velocity::from_m_per_sec(self.as_m_per_s2() * time_delta_to_secs_f64(rhs)) }
 }
 
 
@@ -275,6 +297,19 @@ mod tests {
         let v = a * d;
         assert_eq!(v.as_m_per_sec(), 1000.0);
     }
+
+    #[test]
+    fn test_acceleration_to_velocity_timedelta() {
+        let a = Acceleration::from_m_per_s2(1000.0);
+        let td = time_delta_from_secs_f64(1.0);
+        let v = a * td;
+        assert_eq!(v.as_m_per_sec(), 1000.0);
+
+        // 负时间 → 负速度
+        let neg_td = time_delta_from_secs_f64(-1.0);
+        let v_neg = a * neg_td;
+        assert_eq!(v_neg.as_m_per_sec(), -1000.0);
+    }
     #[test]
     fn test_acceleration_sub() {
         {
@@ -440,6 +475,16 @@ mod tests {
         assert_relative_eq!(v2.as_m_per_sec(), 4.0);
         let v3 = &a1 * dur;
         assert_relative_eq!(v3.as_m_per_sec(), 4.0);
+
+        // 混合引用：* TimeDelta
+        let td = time_delta_from_secs_f64(2.0);
+        let v4 = a1 * &td;
+        assert_relative_eq!(v4.as_m_per_sec(), 4.0);
+        let v5 = &a1 * td;
+        assert_relative_eq!(v5.as_m_per_sec(), 4.0);
+        let td2 = time_delta_from_secs_f64(2.0);
+        let v6 = &a1 * &td2;
+        assert_relative_eq!(v6.as_m_per_sec(), 4.0);
     }
 
     #[test]

--- a/src/physics/basic/angular.rs
+++ b/src/physics/basic/angular.rs
@@ -169,6 +169,14 @@ impl Div<Duration> for Angular {
     }
 }
 
+impl Div<chrono::TimeDelta> for Angular {
+    type Output = AngularVelocity;
+    fn div(self, rhs: chrono::TimeDelta) -> Self::Output {
+        let v = self.as_rad() / time_delta_to_secs_f64(&rhs);
+        AngularVelocity::from_rad_per_second(v)
+    }
+}
+
 // 引用版本：Angular / Duration -> AngularVelocity
 impl<'a> Div<Duration> for &'a Angular {
     type Output = AngularVelocity;
@@ -189,31 +197,51 @@ impl<'a, 'b> Div<&'b Duration> for &'a Angular {
     }
 }
 
+// 引用版本：Angular / TimeDelta -> AngularVelocity
+impl<'a> Div<chrono::TimeDelta> for &'a Angular {
+    type Output = AngularVelocity;
+    fn div(self, rhs: chrono::TimeDelta) -> Self::Output {
+        AngularVelocity::from_rad_per_second(self.as_rad() / time_delta_to_secs_f64(&rhs))
+    }
+}
+impl<'a> Div<&'a chrono::TimeDelta> for Angular {
+    type Output = AngularVelocity;
+    fn div(self, rhs: &'a chrono::TimeDelta) -> Self::Output {
+        AngularVelocity::from_rad_per_second(self.as_rad() / time_delta_to_secs_f64(rhs))
+    }
+}
+impl<'a, 'b> Div<&'b chrono::TimeDelta> for &'a Angular {
+    type Output = AngularVelocity;
+    fn div(self, rhs: &'b chrono::TimeDelta) -> Self::Output {
+        AngularVelocity::from_rad_per_second(self.as_rad() / time_delta_to_secs_f64(rhs))
+    }
+}
+
 impl Div<AngularVelocity> for Angular {
-    type Output = Duration;
+    type Output = chrono::TimeDelta;
     fn div(self, rhs: AngularVelocity) -> Self::Output {
-        Duration::from_secs_f64(self.as_rad() / rhs.as_rad_per_second())
+        time_delta_from_secs_f64(self.as_rad() / rhs.as_rad_per_second())
     }
 }
 
 impl<'a, 'b> Div<&'b AngularVelocity> for &'a Angular {
-    type Output = Duration;
+    type Output = chrono::TimeDelta;
     fn div(self, rhs: &'b AngularVelocity) -> Self::Output {
-        Duration::from_secs_f64(self.as_rad() / rhs.as_rad_per_second())
+        time_delta_from_secs_f64(self.as_rad() / rhs.as_rad_per_second())
     }
 }
 
 impl<'a> Div<&'a AngularVelocity> for Angular {
-    type Output = Duration;
+    type Output = chrono::TimeDelta;
     fn div(self, rhs: &'a AngularVelocity) -> Self::Output {
-        Duration::from_secs_f64(self.as_rad() / rhs.as_rad_per_second())
+        time_delta_from_secs_f64(self.as_rad() / rhs.as_rad_per_second())
     }
 }
 
 impl<'a> Div<AngularVelocity> for &'a Angular {
-    type Output = Duration;
+    type Output = chrono::TimeDelta;
     fn div(self, rhs: AngularVelocity) -> Self::Output {
-        Duration::from_secs_f64(self.as_rad() / rhs.as_rad_per_second())
+        time_delta_from_secs_f64(self.as_rad() / rhs.as_rad_per_second())
     }
 }
 
@@ -418,6 +446,19 @@ mod tests {
     }
 
     #[test]
+    fn test_angular_to_angular_velocity_timedelta() {
+        let theta = Angular::from_rad(PI * 0.5);
+        let td = time_delta_from_secs_f64(2.0);
+        let omg = theta / td;
+        assert_eq!(omg.v, PI / 4.0);
+
+        // 负时间 → 负角速度
+        let neg_td = time_delta_from_secs_f64(-2.0);
+        let omg_neg = theta / neg_td;
+        assert_eq!(omg_neg.as_rad_per_second(), -PI / 4.0);
+    }
+
+    #[test]
     fn test_to_mul() {
         let d1 = Angular::from_rad(1000.0);
         let d2 = d1 * 2.0;
@@ -556,6 +597,16 @@ mod tests {
         assert_relative_eq!(w2.as_rad_per_second(), (std::f64::consts::PI / 12.0));
         let w3 = &a1 / dur;
         assert_relative_eq!(w3.as_rad_per_second(), (std::f64::consts::PI / 12.0));
+
+        // 混合引用：/ TimeDelta
+        let td = time_delta_from_secs_f64(2.0);
+        let w4 = a1 / &td;
+        assert_relative_eq!(w4.as_rad_per_second(), (std::f64::consts::PI / 12.0));
+        let w5 = &a1 / td;
+        assert_relative_eq!(w5.as_rad_per_second(), (std::f64::consts::PI / 12.0));
+        let td2 = time_delta_from_secs_f64(2.0);
+        let w6 = &a1 / &td2;
+        assert_relative_eq!(w6.as_rad_per_second(), (std::f64::consts::PI / 12.0));
     }
 
     #[test]
@@ -593,7 +644,7 @@ mod tests {
             let angle = Angular::from_rad(PI);
             let angular_velocity = AngularVelocity::from_rad_per_second(0.5 * PI);
             let duration = angle / angular_velocity;
-            assert_relative_eq!(duration.as_secs_f64(), 2.0);
+            assert_relative_eq!(time_delta_to_secs_f64(&duration), 2.0);
         }
 
         // 基本测试：度 / 度每秒 = 秒
@@ -601,7 +652,7 @@ mod tests {
             let angle = Angular::from_deg(180.0);
             let angular_velocity = AngularVelocity::from_deg_per_second(90.0);
             let duration = angle / angular_velocity;
-            assert_relative_eq!(duration.as_secs_f64(), 2.0);
+            assert_relative_eq!(time_delta_to_secs_f64(&duration), 2.0);
         }
 
         // 混合单位测试：度 / 弧度每秒
@@ -609,7 +660,7 @@ mod tests {
             let angle = Angular::from_deg(180.0); // π 弧度
             let angular_velocity = AngularVelocity::from_rad_per_second(PI);
             let duration = angle / angular_velocity;
-            assert_relative_eq!(duration.as_secs_f64(), 1.0);
+            assert_relative_eq!(time_delta_to_secs_f64(&duration), 1.0);
         }
 
         // 混合单位测试：弧度 / 度每秒
@@ -617,7 +668,7 @@ mod tests {
             let angle = Angular::from_rad(PI);
             let angular_velocity = AngularVelocity::from_deg_per_second(180.0); // π 弧度/秒
             let duration = angle / angular_velocity;
-            assert_relative_eq!(duration.as_secs_f64(), 1.0);
+            assert_relative_eq!(time_delta_to_secs_f64(&duration), 1.0);
         }
 
         // 测试弧度/小时单位
@@ -625,7 +676,7 @@ mod tests {
             let angle = Angular::from_rad(2.0 * PI);
             let angular_velocity = AngularVelocity::from_rad_per_hour(3600.0 * PI); // π 弧度/秒 = 3600π 弧度/小时
             let duration = angle / angular_velocity;
-            assert_relative_eq!(duration.as_secs_f64(), 2.0);
+            assert_relative_eq!(time_delta_to_secs_f64(&duration), 2.0);
         }
 
         // 测试度/小时单位
@@ -633,7 +684,7 @@ mod tests {
             let angle = Angular::from_deg(360.0);
             let angular_velocity = AngularVelocity::from_deg_per_hour(180.0 * 3600.0); // 180度/秒 = 180*3600度/小时
             let duration = angle / angular_velocity;
-            assert_relative_eq!(duration.as_secs_f64(), 2.0);
+            assert_relative_eq!(time_delta_to_secs_f64(&duration), 2.0);
         }
 
         // 引用-引用测试
@@ -641,7 +692,7 @@ mod tests {
             let angle = Angular::from_rad(PI);
             let angular_velocity = AngularVelocity::from_rad_per_second(0.5 * PI);
             let duration = &angle / &angular_velocity;
-            assert_relative_eq!(duration.as_secs_f64(), 2.0);
+            assert_relative_eq!(time_delta_to_secs_f64(&duration), 2.0);
         }
 
         // 混合引用测试：值 / 引用
@@ -649,7 +700,7 @@ mod tests {
             let angle = Angular::from_rad(PI);
             let angular_velocity = AngularVelocity::from_rad_per_second(0.5 * PI);
             let duration = angle / &angular_velocity;
-            assert_relative_eq!(duration.as_secs_f64(), 2.0);
+            assert_relative_eq!(time_delta_to_secs_f64(&duration), 2.0);
         }
 
         // 混合引用测试：引用 / 值
@@ -657,7 +708,7 @@ mod tests {
             let angle = Angular::from_rad(PI);
             let angular_velocity = AngularVelocity::from_rad_per_second(0.5 * PI);
             let duration = &angle / angular_velocity;
-            assert_relative_eq!(duration.as_secs_f64(), 2.0);
+            assert_relative_eq!(time_delta_to_secs_f64(&duration), 2.0);
         }
 
         // 测试不同单位的混合引用
@@ -665,21 +716,21 @@ mod tests {
             let angle = Angular::from_deg(90.0);
             let angular_velocity = AngularVelocity::from_rad_per_second(PI / 2.0);
             let duration = &angle / &angular_velocity;
-            assert_relative_eq!(duration.as_secs_f64(), 1.0);
+            assert_relative_eq!(time_delta_to_secs_f64(&duration), 1.0);
         }
 
         {
             let angle = Angular::from_deg(90.0);
             let angular_velocity = AngularVelocity::from_rad_per_second(PI / 2.0);
             let duration = angle / &angular_velocity;
-            assert_relative_eq!(duration.as_secs_f64(), 1.0);
+            assert_relative_eq!(time_delta_to_secs_f64(&duration), 1.0);
         }
 
         {
             let angle = Angular::from_deg(90.0);
             let angular_velocity = AngularVelocity::from_rad_per_second(PI / 2.0);
             let duration = &angle / angular_velocity;
-            assert_relative_eq!(duration.as_secs_f64(), 1.0);
+            assert_relative_eq!(time_delta_to_secs_f64(&duration), 1.0);
         }
 
         // 测试零角度
@@ -687,7 +738,7 @@ mod tests {
             let angle = Angular::from_rad(0.0);
             let angular_velocity = AngularVelocity::from_rad_per_second(1.0);
             let duration = angle / angular_velocity;
-            assert_relative_eq!(duration.as_secs_f64(), 0.0);
+            assert_relative_eq!(time_delta_to_secs_f64(&duration), 0.0);
         }
 
         // 测试大角度
@@ -695,7 +746,7 @@ mod tests {
             let angle = Angular::from_rad(10.0 * PI);
             let angular_velocity = AngularVelocity::from_rad_per_second(PI);
             let duration = angle / angular_velocity;
-            assert_relative_eq!(duration.as_secs_f64(), 10.0);
+            assert_relative_eq!(time_delta_to_secs_f64(&duration), 10.0);
         }
 
         // 测试小角速度
@@ -703,7 +754,15 @@ mod tests {
             let angle = Angular::from_rad(PI);
             let angular_velocity = AngularVelocity::from_rad_per_second(0.1);
             let duration = angle / angular_velocity;
-            assert_relative_eq!(duration.as_secs_f64(), 10.0 * PI, epsilon = 1e-8);
+            assert_relative_eq!(time_delta_to_secs_f64(&duration), 10.0 * PI, epsilon = 1e-8);
+        }
+
+        // 负角度 → 负时间
+        {
+            let angle = Angular::from_rad(-PI);
+            let angular_velocity = AngularVelocity::from_rad_per_second(PI);
+            let duration = angle / angular_velocity;
+            assert_relative_eq!(time_delta_to_secs_f64(&duration), -1.0);
         }
     }
 }

--- a/src/physics/basic/angular_acceleration.rs
+++ b/src/physics/basic/angular_acceleration.rs
@@ -62,6 +62,15 @@ impl Div<Duration> for AngularAcceleration {
     }
 }
 
+impl Div<chrono::TimeDelta> for AngularAcceleration {
+    type Output = AngularVelocity;
+
+    fn div(self, rhs: chrono::TimeDelta) -> Self::Output {
+        let v = self.as_rad_per_second2() / time_delta_to_secs_f64(&rhs);
+        AngularVelocity::from_rad_per_second(v)
+    }
+}
+
 
 impl Add for AngularAcceleration {
     type Output = Self;
@@ -138,6 +147,15 @@ impl Mul<Duration> for AngularAcceleration {
     }
 }
 
+impl Mul<chrono::TimeDelta> for AngularAcceleration {
+    type Output = AngularVelocity;
+
+    fn mul(self, rhs: chrono::TimeDelta) -> Self::Output {
+        let v = self.as_rad_per_second2() * time_delta_to_secs_f64(&rhs);
+        AngularVelocity::from_rad_per_second(v)
+    }
+}
+
 // 引用版本：AngularAcceleration * Duration -> AngularVelocity
 impl<'a> Mul<Duration> for &'a AngularAcceleration {
     type Output = AngularVelocity;
@@ -150,6 +168,20 @@ impl<'a> Mul<&'a Duration> for AngularAcceleration {
 impl<'a, 'b> Mul<&'b Duration> for &'a AngularAcceleration {
     type Output = AngularVelocity;
     fn mul(self, rhs: &'b Duration) -> Self::Output { AngularVelocity::from_rad_per_second(self.as_rad_per_second2() * rhs.as_secs_f64()) }
+}
+
+// 引用版本：AngularAcceleration * TimeDelta -> AngularVelocity
+impl<'a> Mul<chrono::TimeDelta> for &'a AngularAcceleration {
+    type Output = AngularVelocity;
+    fn mul(self, rhs: chrono::TimeDelta) -> Self::Output { AngularVelocity::from_rad_per_second(self.as_rad_per_second2() * time_delta_to_secs_f64(&rhs)) }
+}
+impl<'a> Mul<&'a chrono::TimeDelta> for AngularAcceleration {
+    type Output = AngularVelocity;
+    fn mul(self, rhs: &'a chrono::TimeDelta) -> Self::Output { AngularVelocity::from_rad_per_second(self.as_rad_per_second2() * time_delta_to_secs_f64(rhs)) }
+}
+impl<'a, 'b> Mul<&'b chrono::TimeDelta> for &'a AngularAcceleration {
+    type Output = AngularVelocity;
+    fn mul(self, rhs: &'b chrono::TimeDelta) -> Self::Output { AngularVelocity::from_rad_per_second(self.as_rad_per_second2() * time_delta_to_secs_f64(rhs)) }
 }
 
 // 从角加速度变成线加速度
@@ -275,6 +307,27 @@ mod tests {
         let alpha1 = AngularAcceleration::from_rad_per_second2(PI);
         let omg = alpha1 * duration;
         assert_relative_eq!(omg.as_rad_per_second(), 10.0* PI);
+    }
+
+    #[test]
+    fn test_angular_acceleration_change_timedelta() {
+        let alpha = AngularAcceleration::from_rad_per_second2(PI);
+        let td = time_delta_from_secs_f64(10.0);
+        let omg = alpha / td;
+        assert_relative_eq!(omg.as_rad_per_second(), 0.1 * PI);
+
+        // 负时间 → 负角速度
+        let neg_td = time_delta_from_secs_f64(-10.0);
+        let omg_neg = alpha / neg_td;
+        assert_relative_eq!(omg_neg.as_rad_per_second(), -0.1 * PI);
+
+        // 乘法
+        let omg2 = alpha * td;
+        assert_relative_eq!(omg2.as_rad_per_second(), 10.0 * PI);
+
+        // 负时间乘法
+        let omg_neg2 = alpha * neg_td;
+        assert_relative_eq!(omg_neg2.as_rad_per_second(), -10.0 * PI);
     }
 
     #[test]
@@ -449,6 +502,16 @@ mod tests {
         assert_relative_eq!(w2.as_rad_per_second(), 2.0 * std::f64::consts::PI);
         let w3 = &a1 * dur;
         assert_relative_eq!(w3.as_rad_per_second(), 2.0 * std::f64::consts::PI);
+
+        // 混合引用：* TimeDelta
+        let td = time_delta_from_secs_f64(2.0);
+        let w4 = a1 * &td;
+        assert_relative_eq!(w4.as_rad_per_second(), 2.0 * std::f64::consts::PI);
+        let w5 = &a1 * td;
+        assert_relative_eq!(w5.as_rad_per_second(), 2.0 * std::f64::consts::PI);
+        let td2 = time_delta_from_secs_f64(2.0);
+        let w6 = &a1 * &td2;
+        assert_relative_eq!(w6.as_rad_per_second(), 2.0 * std::f64::consts::PI);
 
         // 混合引用：* Distance
         let acc2 = a1 * &Distance::from_m(2.0);

--- a/src/physics/basic/angular_velocity.rs
+++ b/src/physics/basic/angular_velocity.rs
@@ -95,12 +95,29 @@ impl Mul<Duration> for AngularVelocity {
     }
 }
 
+impl Mul<chrono::TimeDelta> for AngularVelocity {
+    type Output = Angular;
+    fn mul(self, rhs: chrono::TimeDelta) -> Self::Output {
+        let v = self.as_rad_per_second() * time_delta_to_secs_f64(&rhs);
+        Angular::from_rad(v)
+    }
+}
+
 
 impl Div<Duration> for AngularVelocity {
     type Output = AngularAcceleration;
 
     fn div(self, rhs: Duration) -> Self::Output {
         let v = self.as_rad_per_second() / rhs.as_secs_f64();
+        AngularAcceleration::from_rad_per_second2(v)
+    }
+}
+
+impl Div<chrono::TimeDelta> for AngularVelocity {
+    type Output = AngularAcceleration;
+
+    fn div(self, rhs: chrono::TimeDelta) -> Self::Output {
+        let v = self.as_rad_per_second() / time_delta_to_secs_f64(&rhs);
         AngularAcceleration::from_rad_per_second2(v)
     }
 }
@@ -285,27 +302,27 @@ impl<'a> Div<AngularVelocity> for &'a AngularVelocity {
     fn div(self, rhs: AngularVelocity) -> Self::Output { Coef::new(self.as_rad_per_second() / rhs.as_rad_per_second()) }
 }
 
-// 角速度 ÷ 角加速度 = 时间
+// 角速度 ÷ 角加速度 = 有符号时间
 impl Div<AngularAcceleration> for AngularVelocity {
-    type Output = std::time::Duration;
+    type Output = chrono::TimeDelta;
     fn div(self, rhs: AngularAcceleration) -> Self::Output {
         let time_value = self.as_rad_per_second() / rhs.as_rad_per_second2();
-        std::time::Duration::from_secs_f64(time_value)
+        time_delta_from_secs_f64(time_value)
     }
 }
 
-// 引用版本：AngularVelocity / AngularAcceleration -> Duration
+// 引用版本：AngularVelocity / AngularAcceleration -> TimeDelta
 impl<'a, 'b> Div<&'b AngularAcceleration> for &'a AngularVelocity {
-    type Output = std::time::Duration;
-    fn div(self, rhs: &'b AngularAcceleration) -> Self::Output { std::time::Duration::from_secs_f64(self.as_rad_per_second() / rhs.as_rad_per_second2()) }
+    type Output = chrono::TimeDelta;
+    fn div(self, rhs: &'b AngularAcceleration) -> Self::Output { time_delta_from_secs_f64(self.as_rad_per_second() / rhs.as_rad_per_second2()) }
 }
 impl<'a> Div<&'a AngularAcceleration> for AngularVelocity {
-    type Output = std::time::Duration;
-    fn div(self, rhs: &'a AngularAcceleration) -> Self::Output { std::time::Duration::from_secs_f64(self.as_rad_per_second() / rhs.as_rad_per_second2()) }
+    type Output = chrono::TimeDelta;
+    fn div(self, rhs: &'a AngularAcceleration) -> Self::Output { time_delta_from_secs_f64(self.as_rad_per_second() / rhs.as_rad_per_second2()) }
 }
 impl<'a> Div<AngularAcceleration> for &'a AngularVelocity {
-    type Output = std::time::Duration;
-    fn div(self, rhs: AngularAcceleration) -> Self::Output { std::time::Duration::from_secs_f64(self.as_rad_per_second() / rhs.as_rad_per_second2()) }
+    type Output = chrono::TimeDelta;
+    fn div(self, rhs: AngularAcceleration) -> Self::Output { time_delta_from_secs_f64(self.as_rad_per_second() / rhs.as_rad_per_second2()) }
 }
 
 impl Neg for AngularVelocity {
@@ -385,6 +402,27 @@ mod tests {
         let alpha = omg1 / duration;
         assert_eq!(alpha.default_type, AngularAccelerationType::RadperSecond2);
         assert_relative_eq!(alpha.as_rad_per_second2(),5.0);
+    }
+
+    #[test]
+    fn test_angular_velocity_change_timedelta() {
+        let omg = AngularVelocity::from_rad_per_second(10.0);
+        let td = time_delta_from_secs_f64(2.0);
+        let theta = omg * td;
+        assert_eq!(theta.as_rad(), 20.0);
+
+        // 负时间 → 负角度
+        let neg_td = time_delta_from_secs_f64(-2.0);
+        let theta_neg = omg * neg_td;
+        assert_eq!(theta_neg.as_rad(), -20.0);
+
+        // 除法：AngularVelocity / TimeDelta → AngularAcceleration
+        let alpha = omg / td;
+        assert_relative_eq!(alpha.as_rad_per_second2(), 5.0);
+
+        // 负时间 → 负角加速度
+        let alpha_neg = omg / neg_td;
+        assert_relative_eq!(alpha_neg.as_rad_per_second2(), -5.0);
     }
 
     #[test]
@@ -585,7 +623,7 @@ mod tests {
             let omega = AngularVelocity::from_rad_per_second(10.0);
             let alpha = AngularAcceleration::from_rad_per_second2(2.0);
             let duration = omega / alpha;
-            assert_relative_eq!(duration.as_secs_f64(), 5.0);
+            assert_relative_eq!(time_delta_to_secs_f64(&duration), 5.0);
         }
 
         // 基本测试：度每秒 / 度每秒² = 秒
@@ -593,7 +631,7 @@ mod tests {
             let omega = AngularVelocity::from_deg_per_second(180.0);
             let alpha = AngularAcceleration::from_deg_per_second2(90.0);
             let duration = omega / alpha;
-            assert_relative_eq!(duration.as_secs_f64(), 2.0);
+            assert_relative_eq!(time_delta_to_secs_f64(&duration), 2.0);
         }
 
         // 混合单位测试：度每秒 / 弧度每秒²
@@ -601,7 +639,7 @@ mod tests {
             let omega = AngularVelocity::from_deg_per_second(180.0); // π 弧度/秒
             let alpha = AngularAcceleration::from_rad_per_second2(PI);
             let duration = omega / alpha;
-            assert_relative_eq!(duration.as_secs_f64(), 1.0);
+            assert_relative_eq!(time_delta_to_secs_f64(&duration), 1.0);
         }
 
         // 混合单位测试：弧度每秒 / 度每秒²
@@ -609,7 +647,7 @@ mod tests {
             let omega = AngularVelocity::from_rad_per_second(PI);
             let alpha = AngularAcceleration::from_deg_per_second2(180.0); // π 弧度/秒²
             let duration = omega / alpha;
-            assert_relative_eq!(duration.as_secs_f64(), 1.0);
+            assert_relative_eq!(time_delta_to_secs_f64(&duration), 1.0);
         }
 
         // 测试弧度/小时单位
@@ -617,7 +655,7 @@ mod tests {
             let omega = AngularVelocity::from_rad_per_hour(3600.0 * PI); // π 弧度/秒 = 3600π 弧度/小时
             let alpha = AngularAcceleration::from_rad_per_second2(PI);
             let duration = omega / alpha;
-            assert_relative_eq!(duration.as_secs_f64(), 1.0);
+            assert_relative_eq!(time_delta_to_secs_f64(&duration), 1.0);
         }
 
         // 测试度/小时单位
@@ -625,7 +663,7 @@ mod tests {
             let omega = AngularVelocity::from_deg_per_hour(180.0 * 3600.0); // 180度/秒 = 180*3600度/小时
             let alpha = AngularAcceleration::from_deg_per_second2(180.0);
             let duration = omega / alpha;
-            assert_relative_eq!(duration.as_secs_f64(), 1.0);
+            assert_relative_eq!(time_delta_to_secs_f64(&duration), 1.0);
         }
 
         // 引用-引用测试
@@ -633,7 +671,7 @@ mod tests {
             let omega = AngularVelocity::from_rad_per_second(10.0);
             let alpha = AngularAcceleration::from_rad_per_second2(2.0);
             let duration = &omega / &alpha;
-            assert_relative_eq!(duration.as_secs_f64(), 5.0);
+            assert_relative_eq!(time_delta_to_secs_f64(&duration), 5.0);
         }
 
         // 混合引用测试：值 / 引用
@@ -641,7 +679,7 @@ mod tests {
             let omega = AngularVelocity::from_rad_per_second(10.0);
             let alpha = AngularAcceleration::from_rad_per_second2(2.0);
             let duration = omega / &alpha;
-            assert_relative_eq!(duration.as_secs_f64(), 5.0);
+            assert_relative_eq!(time_delta_to_secs_f64(&duration), 5.0);
         }
 
         // 混合引用测试：引用 / 值
@@ -649,7 +687,7 @@ mod tests {
             let omega = AngularVelocity::from_rad_per_second(10.0);
             let alpha = AngularAcceleration::from_rad_per_second2(2.0);
             let duration = &omega / alpha;
-            assert_relative_eq!(duration.as_secs_f64(), 5.0);
+            assert_relative_eq!(time_delta_to_secs_f64(&duration), 5.0);
         }
 
         // 测试不同单位的混合引用
@@ -657,21 +695,21 @@ mod tests {
             let omega = AngularVelocity::from_deg_per_second(180.0);
             let alpha = AngularAcceleration::from_rad_per_second2(PI);
             let duration = &omega / &alpha;
-            assert_relative_eq!(duration.as_secs_f64(), 1.0);
+            assert_relative_eq!(time_delta_to_secs_f64(&duration), 1.0);
         }
 
         {
             let omega = AngularVelocity::from_deg_per_second(180.0);
             let alpha = AngularAcceleration::from_rad_per_second2(PI);
             let duration = omega / &alpha;
-            assert_relative_eq!(duration.as_secs_f64(), 1.0);
+            assert_relative_eq!(time_delta_to_secs_f64(&duration), 1.0);
         }
 
         {
             let omega = AngularVelocity::from_deg_per_second(180.0);
             let alpha = AngularAcceleration::from_rad_per_second2(PI);
             let duration = &omega / alpha;
-            assert_relative_eq!(duration.as_secs_f64(), 1.0);
+            assert_relative_eq!(time_delta_to_secs_f64(&duration), 1.0);
         }
 
         // 测试零角速度
@@ -679,7 +717,7 @@ mod tests {
             let omega = AngularVelocity::from_rad_per_second(0.0);
             let alpha = AngularAcceleration::from_rad_per_second2(1.0);
             let duration = omega / alpha;
-            assert_relative_eq!(duration.as_secs_f64(), 0.0);
+            assert_relative_eq!(time_delta_to_secs_f64(&duration), 0.0);
         }
 
         // 测试大角速度
@@ -687,7 +725,7 @@ mod tests {
             let omega = AngularVelocity::from_rad_per_second(100.0 * PI);
             let alpha = AngularAcceleration::from_rad_per_second2(PI);
             let duration = omega / alpha;
-            assert_relative_eq!(duration.as_secs_f64(), 100.0);
+            assert_relative_eq!(time_delta_to_secs_f64(&duration), 100.0);
         }
 
         // 测试小角加速度
@@ -695,7 +733,15 @@ mod tests {
             let omega = AngularVelocity::from_rad_per_second(PI);
             let alpha = AngularAcceleration::from_rad_per_second2(0.1);
             let duration = omega / alpha;
-            assert_relative_eq!(duration.as_secs_f64(), 10.0 * PI, epsilon = 1e-8);
+            assert_relative_eq!(time_delta_to_secs_f64(&duration), 10.0 * PI, epsilon = 1e-8);
+        }
+
+        // 负角速度 → 负时间
+        {
+            let omega = AngularVelocity::from_rad_per_second(-10.0);
+            let alpha = AngularAcceleration::from_rad_per_second2(2.0);
+            let duration = omega / alpha;
+            assert_relative_eq!(time_delta_to_secs_f64(&duration), -5.0);
         }
     }
 
@@ -744,7 +790,7 @@ mod tests {
         assert_relative_eq!(coef.get_value(), 1.0);
 
         let t = &w1 / &AngularAcceleration::from_rad_per_second2(std::f64::consts::PI);
-        assert_relative_eq!(t.as_secs_f64(), 1.0);
+        assert_relative_eq!(time_delta_to_secs_f64(&t), 1.0);
 
         // 混合引用：加/减
         let s2 = w1 + &w2;
@@ -771,8 +817,8 @@ mod tests {
 
         // 混合引用：/ AngularAcceleration -> Duration
         let ta = w1 / &AngularAcceleration::from_rad_per_second2(std::f64::consts::PI);
-        assert_relative_eq!(ta.as_secs_f64(), 1.0);
+        assert_relative_eq!(time_delta_to_secs_f64(&ta), 1.0);
         let tb = &w1 / AngularAcceleration::from_rad_per_second2(std::f64::consts::PI);
-        assert_relative_eq!(tb.as_secs_f64(), 1.0);
+        assert_relative_eq!(time_delta_to_secs_f64(&tb), 1.0);
     }
 }

--- a/src/physics/basic/coef.rs
+++ b/src/physics/basic/coef.rs
@@ -115,6 +115,15 @@ impl Mul<Duration> for Coef {
     }
 }
 
+impl Mul<chrono::TimeDelta> for Coef {
+    type Output = Coef;
+
+    fn mul(self, rhs: chrono::TimeDelta) -> Self::Output {
+        let v = self.get_value() * time_delta_to_secs_f64(&rhs);
+        Coef { v }
+    }
+}
+
 impl Div for Coef {
     type Output = Coef;
     fn div(self, rhs: Self) -> Self::Output {
@@ -341,6 +350,16 @@ mod tests {
         let coef = Coef::new(2.0);
         let result = coef * Duration::from_secs(10);
         assert_eq!(result.get_value(), 20.0);
+
+        let coef = Coef::new(2.0);
+        let td = time_delta_from_secs_f64(10.0);
+        let result = coef * td;
+        assert_eq!(result.get_value(), 20.0);
+
+        // 负时间
+        let neg_td = time_delta_from_secs_f64(-3.0);
+        let result_neg = coef * neg_td;
+        assert_eq!(result_neg.get_value(), -6.0);
 
         let coef = Coef::new(2.0);
         let result = 2.0 * coef;

--- a/src/physics/basic/distance.rs
+++ b/src/physics/basic/distance.rs
@@ -60,6 +60,15 @@ impl Div<Duration> for Distance {
         Velocity::from_m_per_sec(v)
     }
 }
+
+impl Div<chrono::TimeDelta> for Distance {
+    type Output = Velocity;
+
+    fn div(self, rhs: chrono::TimeDelta) -> Self::Output {
+        let v = self.as_m() / time_delta_to_secs_f64(&rhs);
+        Velocity::from_m_per_sec(v)
+    }
+}
 impl Add for Distance {
     type Output = Self;
     fn add(self, rhs: Self) -> Self::Output {
@@ -244,12 +253,12 @@ impl<'a> Div<Distance> for &'a Distance {
     fn div(self, rhs: Distance) -> Self::Output { Coef::new(self.as_m() / rhs.as_m()) }
 }
 
-// 距离 ÷ 速度 = 时间
+// 距离 ÷ 速度 = 有符号时间
 impl Div<Velocity> for Distance {
-    type Output = std::time::Duration;
+    type Output = chrono::TimeDelta;
     fn div(self, rhs: Velocity) -> Self::Output {
         let time_value = self.as_m() / rhs.as_m_per_sec();
-        std::time::Duration::from_secs_f64(time_value)
+        time_delta_from_secs_f64(time_value)
     }
 }
 
@@ -295,6 +304,25 @@ mod tests {
         let duration = Duration::from_secs(60 * 60 * 24);
         let v = d1 / duration;
         assert_eq!(v.as_km_per_h(), 50.0);
+    }
+
+    #[test]
+    fn test_to_velocity_with_timedelta() {
+        let d1 = Distance::from_m(1000.0);
+        let td = time_delta_from_secs_f64(5.0);
+        let v = d1 / td;
+        assert_eq!(v.as_m_per_sec(), 200.0);
+
+        // 负时间：距离为正，时间负 → 速度负
+        let neg_td = time_delta_from_secs_f64(-5.0);
+        let v_neg = d1 / neg_td;
+        assert_eq!(v_neg.as_m_per_sec(), -200.0);
+
+        // 距离为负
+        let d_neg = Distance::from_m(-100.0);
+        let td2 = time_delta_from_secs_f64(2.0);
+        let v2 = d_neg / td2;
+        assert_eq!(v2.as_m_per_sec(), -50.0);
     }
 
     #[test]
@@ -455,7 +483,12 @@ mod tests {
         let velocity = Velocity::from_m_per_sec(20.0); // 20 m/s
         let time = distance / velocity; // 5 s
         
-        assert_relative_eq!(time.as_secs_f64(), 5.0);
+        assert_relative_eq!(time_delta_to_secs_f64(&time), 5.0);
+
+        // 距离和速度方向相反 → 负数时间
+        let dist_neg = Distance::from_m(-100.0);
+        let time_neg = dist_neg / velocity;
+        assert_relative_eq!(time_delta_to_secs_f64(&time_neg), -5.0);
     }
 
     #[test]

--- a/src/physics/basic/energy.rs
+++ b/src/physics/basic/energy.rs
@@ -1,5 +1,6 @@
 use crate::physics::basic::{
     Acceleration, Coef, Distance, Energy, EnergyType, Force, Mass, PhysicalQuantity, Velocity,
+    time_delta_from_secs_f64, time_delta_to_secs_f64,
 };
 use approx::assert_relative_eq;
 use std::any::Any;
@@ -355,6 +356,14 @@ impl Div<std::time::Duration> for Energy {
     }
 }
 
+impl Div<chrono::TimeDelta> for Energy {
+    type Output = crate::physics::basic::Power;
+    fn div(self, rhs: chrono::TimeDelta) -> Self::Output {
+        let power_value = self.as_joule() / time_delta_to_secs_f64(&rhs);
+        crate::physics::basic::Power::from_watt(power_value)
+    }
+}
+
 // 引用版本：Energy / Duration -> Power
 impl<'a> Div<std::time::Duration> for &'a Energy {
     type Output = crate::physics::basic::Power;
@@ -367,6 +376,20 @@ impl<'a> Div<&'a std::time::Duration> for Energy {
 impl<'a, 'b> Div<&'b std::time::Duration> for &'a Energy {
     type Output = crate::physics::basic::Power;
     fn div(self, rhs: &'b std::time::Duration) -> Self::Output { crate::physics::basic::Power::from_watt(self.as_joule() / rhs.as_secs_f64()) }
+}
+
+// 引用版本：Energy / TimeDelta -> Power
+impl<'a> Div<chrono::TimeDelta> for &'a Energy {
+    type Output = crate::physics::basic::Power;
+    fn div(self, rhs: chrono::TimeDelta) -> Self::Output { crate::physics::basic::Power::from_watt(self.as_joule() / time_delta_to_secs_f64(&rhs)) }
+}
+impl<'a> Div<&'a chrono::TimeDelta> for Energy {
+    type Output = crate::physics::basic::Power;
+    fn div(self, rhs: &'a chrono::TimeDelta) -> Self::Output { crate::physics::basic::Power::from_watt(self.as_joule() / time_delta_to_secs_f64(rhs)) }
+}
+impl<'a, 'b> Div<&'b chrono::TimeDelta> for &'a Energy {
+    type Output = crate::physics::basic::Power;
+    fn div(self, rhs: &'b chrono::TimeDelta) -> Self::Output { crate::physics::basic::Power::from_watt(self.as_joule() / time_delta_to_secs_f64(rhs)) }
 }
 
 // 能量 ÷ 距离 = 力
@@ -969,6 +992,19 @@ mod tests {
     }
 
     #[test]
+    fn test_energy_div_timedelta() {
+        let energy = Energy::from_joule(100.0); // 100 J
+        let td = time_delta_from_secs_f64(5.0);
+        let power: crate::physics::basic::Power = energy / td;
+        assert_relative_eq!(power.as_watt(), 20.0);
+
+        // 负时间 → 负功率
+        let neg_td = time_delta_from_secs_f64(-5.0);
+        let power_neg: crate::physics::basic::Power = energy / neg_td;
+        assert_relative_eq!(power_neg.as_watt(), -20.0);
+    }
+
+    #[test]
     fn test_energy_div_distance() {
         let energy = Energy::from_joule(60.0); // 60 J
         let distance = Distance::from_m(3.0); // 3 m
@@ -1010,6 +1046,16 @@ mod tests {
         assert_relative_eq!(p2.as_watt(), 5.0);
         let p3 = &e1 / dur;
         assert_relative_eq!(p3.as_watt(), 5.0);
+
+        // 混合引用：/ TimeDelta
+        let td = time_delta_from_secs_f64(2.0);
+        let p4 = e1 / &td;
+        assert_relative_eq!(p4.as_watt(), 5.0);
+        let p5 = &e1 / td;
+        assert_relative_eq!(p5.as_watt(), 5.0);
+        let td2 = time_delta_from_secs_f64(2.0);
+        let p6 = &e1 / &td2;
+        assert_relative_eq!(p6.as_watt(), 5.0);
 
         // 混合引用：/ Distance
         let f2 = e1 / &Distance::from_m(2.0);

--- a/src/physics/basic/power.rs
+++ b/src/physics/basic/power.rs
@@ -1,6 +1,7 @@
 use std::any::Any;
 use std::ops::{Add, Div, Mul, Neg, Sub};
-use crate::physics::basic::{Coef, Power, PowerType, PhysicalQuantity, Energy, Velocity, Force};
+use crate::physics::basic::{Coef, Power, PowerType, PhysicalQuantity, Energy, Velocity, Force,
+    time_delta_from_secs_f64, time_delta_to_secs_f64};
 use approx::assert_relative_eq;
 
 impl Default for Power {
@@ -339,11 +340,27 @@ impl Mul<std::time::Duration> for Power {
     }
 }
 
+impl Mul<chrono::TimeDelta> for Power {
+    type Output = Energy; // 能量，单位：焦耳
+    fn mul(self, rhs: chrono::TimeDelta) -> Self::Output {
+        let energy_value = self.as_watt() * time_delta_to_secs_f64(&rhs);
+        Energy::from_joule(energy_value)
+    }
+}
+
 // 时间与功率的乘积（得到能量，满足交换律）
 impl Mul<Power> for std::time::Duration {
     type Output = Energy; // 能量，单位：焦耳
     fn mul(self, rhs: Power) -> Self::Output {
         let energy_value = self.as_secs_f64() * rhs.as_watt();
+        Energy::from_joule(energy_value)
+    }
+}
+
+impl Mul<Power> for chrono::TimeDelta {
+    type Output = Energy; // 能量，单位：焦耳
+    fn mul(self, rhs: Power) -> Self::Output {
+        let energy_value = time_delta_to_secs_f64(&self) * rhs.as_watt();
         Energy::from_joule(energy_value)
     }
 }
@@ -444,6 +461,23 @@ mod tests {
         let energy: Energy = power * time; // 500 J
         
         assert_relative_eq!(energy.as_joule(), 500.0);
+    }
+
+    #[test]
+    fn test_power_mul_timedelta() {
+        let power = Power::from_watt(100.0); // 100 W
+        let td = time_delta_from_secs_f64(5.0);
+        let energy: Energy = power * td;
+        assert_relative_eq!(energy.as_joule(), 500.0);
+
+        // 负时间 → 负能量
+        let neg_td = time_delta_from_secs_f64(-5.0);
+        let energy_neg: Energy = power * neg_td;
+        assert_relative_eq!(energy_neg.as_joule(), -500.0);
+
+        // 交换律：TimeDelta * Power
+        let energy_comm: Energy = td * power;
+        assert_relative_eq!(energy_comm.as_joule(), 500.0);
     }
 
     #[test]

--- a/src/physics/basic/vector/angular_velocity.rs
+++ b/src/physics/basic/vector/angular_velocity.rs
@@ -1,6 +1,7 @@
 use std::ops::Mul;
 use std::time::Duration;
-use crate::physics::basic::{Angular, AngularVelocity, AngularVelocityType, Coef, Vector3};
+use crate::physics::basic::{Angular, AngularVelocity, AngularVelocityType, Coef, Vector3,
+    time_delta_from_secs_f64, time_delta_to_secs_f64};
 use crate::utils::float;
 
 impl Vector3<AngularVelocity> {
@@ -117,6 +118,17 @@ impl Mul<Duration> for Vector3<AngularVelocity> {
     }
 }
 
+impl Mul<chrono::TimeDelta> for Vector3<AngularVelocity> {
+    type Output = Vector3<Angular>;
+
+    fn mul(self, rhs: chrono::TimeDelta) -> Self::Output {
+        let x= self.x * rhs;
+        let y= self.y * rhs;
+        let z = self.z * rhs;
+        Vector3::new(x, y, z)
+    }
+}
+
 #[cfg(test)]
 mod test {
     use approx::assert_relative_eq;
@@ -191,6 +203,23 @@ mod test {
         assert_relative_eq!(v2.x.as_rad(),2.0);
         assert_relative_eq!(v2.y.as_rad(),4.0);
         assert_relative_eq!(v2.z.as_rad(),6.0);
+    }
+
+    #[test]
+    fn test_convert_timedelta(){
+        let v:Vector3<AngularVelocity> = Vector3::new(AngularVelocity::from_rad_per_second(1.0),AngularVelocity::from_rad_per_second(2.0),AngularVelocity::from_rad_per_second(3.0));
+        let td = time_delta_from_secs_f64(2.0);
+        let v2 = v * td;
+        assert_relative_eq!(v2.x.as_rad(),2.0);
+        assert_relative_eq!(v2.y.as_rad(),4.0);
+        assert_relative_eq!(v2.z.as_rad(),6.0);
+
+        // 负时间 → 负角度
+        let neg_td = time_delta_from_secs_f64(-2.0);
+        let v_neg = v * neg_td;
+        assert_relative_eq!(v_neg.x.as_rad(),-2.0);
+        assert_relative_eq!(v_neg.y.as_rad(),-4.0);
+        assert_relative_eq!(v_neg.z.as_rad(),-6.0);
     }
 
     #[test]

--- a/src/physics/basic/vector/distance.rs
+++ b/src/physics/basic/vector/distance.rs
@@ -1,5 +1,6 @@
 use crate::physics::basic::{
     AngularMomentum, Coef, Distance, DistanceType, Mass, Momentum, Vector3, Velocity,
+    time_delta_from_secs_f64, time_delta_to_secs_f64,
 };
 use std::ops::{Div, Mul};
 use std::time::Duration;
@@ -19,6 +20,17 @@ impl Div<Duration> for Vector3<Distance> {
     type Output = Vector3<Velocity>;
 
     fn div(self, rhs: Duration) -> Self::Output {
+        let x = self.x / rhs;
+        let y = self.y / rhs;
+        let z = self.z / rhs;
+        Vector3::<Velocity>::new(x, y, z)
+    }
+}
+
+impl Div<chrono::TimeDelta> for Vector3<Distance> {
+    type Output = Vector3<Velocity>;
+
+    fn div(self, rhs: chrono::TimeDelta) -> Self::Output {
         let x = self.x / rhs;
         let y = self.y / rhs;
         let z = self.z / rhs;
@@ -164,6 +176,27 @@ mod tests {
         assert_relative_eq!(v.x.as_m_per_sec(), 1.0);
         assert_relative_eq!(v.y.as_m_per_sec(), 2.0);
         assert_relative_eq!(v.z.as_m_per_sec(), 3.0);
+    }
+
+    #[test]
+    fn test_distance_to_velocity_timedelta() {
+        let a: Vector3<Distance> = Vector3::new(
+            Distance::from_m(10.0),
+            Distance::from_m(20.0),
+            Distance::from_m(30.0),
+        );
+        let td = time_delta_from_secs_f64(10.0);
+        let v = a / td;
+        assert_relative_eq!(v.x.as_m_per_sec(), 1.0);
+        assert_relative_eq!(v.y.as_m_per_sec(), 2.0);
+        assert_relative_eq!(v.z.as_m_per_sec(), 3.0);
+
+        // 负时间 → 负速度
+        let neg_td = time_delta_from_secs_f64(-10.0);
+        let v_neg = a / neg_td;
+        assert_relative_eq!(v_neg.x.as_m_per_sec(), -1.0);
+        assert_relative_eq!(v_neg.y.as_m_per_sec(), -2.0);
+        assert_relative_eq!(v_neg.z.as_m_per_sec(), -3.0);
     }
 
     #[test]

--- a/src/physics/basic/velocity.rs
+++ b/src/physics/basic/velocity.rs
@@ -91,10 +91,27 @@ impl Mul<Duration> for Velocity {
     }
 }
 
+impl Mul<chrono::TimeDelta> for Velocity {
+    type Output = Distance;
+
+    fn mul(self, duration: chrono::TimeDelta) -> Self::Output {
+        let v = self.as_m_per_sec() * time_delta_to_secs_f64(&duration);
+        Distance::from_m(v)
+    }
+}
+
 impl Div<Duration> for Velocity {
     type Output = Acceleration;
     fn div(self, duration: Duration) -> Self::Output {
         let v = self.as_m_per_sec() / duration.as_secs_f64();
+        Acceleration::from_m_per_s2(v)
+    }
+}
+
+impl Div<chrono::TimeDelta> for Velocity {
+    type Output = Acceleration;
+    fn div(self, duration: chrono::TimeDelta) -> Self::Output {
+        let v = self.as_m_per_sec() / time_delta_to_secs_f64(&duration);
         Acceleration::from_m_per_s2(v)
     }
 }
@@ -276,27 +293,27 @@ impl<'a> Div<Distance> for &'a Velocity {
     fn div(self, rhs: Distance) -> Self::Output { AngularVelocity::from_rad_per_second(self.as_m_per_sec() / rhs.as_m()) }
 }
 
-// 速度 ÷ 加速度 = 时间
+// 速度 ÷ 加速度 = 有符号时间
 impl Div<Acceleration> for Velocity {
-    type Output = std::time::Duration;
+    type Output = chrono::TimeDelta;
     fn div(self, rhs: Acceleration) -> Self::Output {
         let time_value = self.as_m_per_sec() / rhs.as_m_per_s2();
-        std::time::Duration::from_secs_f64(time_value)
+        time_delta_from_secs_f64(time_value)
     }
 }
 
-// 引用版本：Velocity / Acceleration -> Duration
+// 引用版本：Velocity / Acceleration -> TimeDelta
 impl<'a, 'b> Div<&'b Acceleration> for &'a Velocity {
-    type Output = std::time::Duration;
-    fn div(self, rhs: &'b Acceleration) -> Self::Output { std::time::Duration::from_secs_f64(self.as_m_per_sec() / rhs.as_m_per_s2()) }
+    type Output = chrono::TimeDelta;
+    fn div(self, rhs: &'b Acceleration) -> Self::Output { time_delta_from_secs_f64(self.as_m_per_sec() / rhs.as_m_per_s2()) }
 }
 impl<'a> Div<&'a Acceleration> for Velocity {
-    type Output = std::time::Duration;
-    fn div(self, rhs: &'a Acceleration) -> Self::Output { std::time::Duration::from_secs_f64(self.as_m_per_sec() / rhs.as_m_per_s2()) }
+    type Output = chrono::TimeDelta;
+    fn div(self, rhs: &'a Acceleration) -> Self::Output { time_delta_from_secs_f64(self.as_m_per_sec() / rhs.as_m_per_s2()) }
 }
 impl<'a> Div<Acceleration> for &'a Velocity {
-    type Output = std::time::Duration;
-    fn div(self, rhs: Acceleration) -> Self::Output { std::time::Duration::from_secs_f64(self.as_m_per_sec() / rhs.as_m_per_s2()) }
+    type Output = chrono::TimeDelta;
+    fn div(self, rhs: Acceleration) -> Self::Output { time_delta_from_secs_f64(self.as_m_per_sec() / rhs.as_m_per_s2()) }
 }
 
 // 引用版本：Velocity * Duration -> Distance
@@ -311,6 +328,20 @@ impl<'a> Mul<&'a std::time::Duration> for Velocity {
 impl<'a, 'b> Mul<&'b std::time::Duration> for &'a Velocity {
     type Output = Distance;
     fn mul(self, duration: &'b std::time::Duration) -> Self::Output { Distance::from_m(self.as_m_per_sec() * duration.as_secs_f64()) }
+}
+
+// 引用版本：Velocity * TimeDelta -> Distance
+impl<'a> Mul<chrono::TimeDelta> for &'a Velocity {
+    type Output = Distance;
+    fn mul(self, duration: chrono::TimeDelta) -> Self::Output { Distance::from_m(self.as_m_per_sec() * time_delta_to_secs_f64(&duration)) }
+}
+impl<'a> Mul<&'a chrono::TimeDelta> for Velocity {
+    type Output = Distance;
+    fn mul(self, duration: &'a chrono::TimeDelta) -> Self::Output { Distance::from_m(self.as_m_per_sec() * time_delta_to_secs_f64(duration)) }
+}
+impl<'a, 'b> Mul<&'b chrono::TimeDelta> for &'a Velocity {
+    type Output = Distance;
+    fn mul(self, duration: &'b chrono::TimeDelta) -> Self::Output { Distance::from_m(self.as_m_per_sec() * time_delta_to_secs_f64(duration)) }
 }
 
 #[cfg(test)]
@@ -392,11 +423,42 @@ mod tests {
     }
 
     #[test]
+    fn test_mul_timedelta() {
+        let v = Velocity::from_m_per_sec(3.0);
+        let td = time_delta_from_secs_f64(15.0);
+        let d = v * td;
+        assert_eq!(d.as_m(), 45.0);
+
+        // 负时间 → 负距离
+        let neg_td = time_delta_from_secs_f64(-15.0);
+        let d_neg = v * neg_td;
+        assert_eq!(d_neg.as_m(), -45.0);
+
+        // 零时间
+        let zero_td = time_delta_from_secs_f64(0.0);
+        let d_zero = v * zero_td;
+        assert_eq!(d_zero.as_m(), 0.0);
+    }
+
+    #[test]
     fn test_div() {
         let v = Velocity::from_m_per_sec(1.0);
         let duration = Duration::from_secs_f64(15.0);
         let d = v / duration;
         assert_eq!(d.as_m_per_s2(), 0.06666666666666667);
+    }
+
+    #[test]
+    fn test_div_timedelta() {
+        let v = Velocity::from_m_per_sec(1.0);
+        let td = time_delta_from_secs_f64(15.0);
+        let a = v / td;
+        assert_eq!(a.as_m_per_s2(), 0.06666666666666667);
+
+        // 负时间 → 负加速度
+        let neg_td = time_delta_from_secs_f64(-2.0);
+        let a_neg = v / neg_td;
+        assert_eq!(a_neg.as_m_per_s2(), -0.5);
     }
 
     #[test]
@@ -566,7 +628,12 @@ mod tests {
         let acceleration = Acceleration::from_m_per_s2(2.0); // 2 m/s²
         let time = velocity / acceleration; // 5 s
         
-        assert_relative_eq!(time.as_secs_f64(), 5.0);
+        assert_relative_eq!(time_delta_to_secs_f64(&time), 5.0);
+
+        // 负速度 → 负时间
+        let vel_neg = Velocity::from_m_per_sec(-10.0);
+        let time_neg = vel_neg / acceleration;
+        assert_relative_eq!(time_delta_to_secs_f64(&time_neg), -5.0);
     }
 
     #[test]
@@ -583,7 +650,7 @@ mod tests {
         assert_relative_eq!(omg.as_rad_per_second(), 1.0);
 
         let t = &v1 / &Acceleration::from_m_per_s2(2.0);
-        assert_relative_eq!(t.as_secs_f64(), 1.0);
+        assert_relative_eq!(time_delta_to_secs_f64(&t), 1.0);
 
         let dist = &v1 * &std::time::Duration::from_secs(2);
         assert_relative_eq!(dist.as_m(), 4.0);
@@ -623,10 +690,10 @@ mod tests {
 
         // 混合引用：/ Acceleration
         let t2 = v1 / &Acceleration::from_m_per_s2(2.0);
-        assert_relative_eq!(t2.as_secs_f64(), 1.0);
+        assert_relative_eq!(time_delta_to_secs_f64(&t2), 1.0);
         let v1f = Velocity::from_m_per_sec(2.0);
         let t3 = &v1f / Acceleration::from_m_per_s2(2.0);
-        assert_relative_eq!(t3.as_secs_f64(), 1.0);
+        assert_relative_eq!(time_delta_to_secs_f64(&t3), 1.0);
 
         // 混合引用：* Duration
         let d4 = v1 * &std::time::Duration::from_secs(2);
@@ -634,5 +701,17 @@ mod tests {
         let v1g = Velocity::from_m_per_sec(2.0);
         let d5 = &v1g * std::time::Duration::from_secs(2);
         assert_relative_eq!(d5.as_m(), 4.0);
+
+        // TimeDelta 引用版本：Velocity * TimeDelta
+        let td = time_delta_from_secs_f64(3.0);
+        let d6 = v1 * &td;
+        assert_relative_eq!(d6.as_m(), 6.0);
+        let v1h = Velocity::from_m_per_sec(2.0);
+        let d7 = &v1h * td;
+        assert_relative_eq!(d7.as_m(), 6.0);
+        let v1i = Velocity::from_m_per_sec(2.0);
+        let td2 = time_delta_from_secs_f64(3.0);
+        let d8 = &v1i * &td2;
+        assert_relative_eq!(d8.as_m(), 6.0);
     }
 }


### PR DESCRIPTION
- Add chrono 0.4 dependency
- Add parallel chrono::TimeDelta implementations for all Duration input ops
- Replace output Duration with TimeDelta for all 4 division ops (Distance/Velocity, Velocity/Acceleration, Angular/AngularVelocity, AngularVelocity/AngularAcceleration) to support negative results
- Add time_delta_from_secs_f64 / time_delta_to_secs_f64 helper functions
- Add 11 new unit tests covering positive, negative, and zero TimeDelta
- Fix example_new_operations.rs for TimeDelta API
- Bump version to 0.3.0