### PR TITLE
test: cover electric cross-type mul and unit branches to 100%

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ Cargo.lock
 .idea/
 *.profraw
 /coverage/
+.workbuddy/

--- a/README.MD
+++ b/README.MD
@@ -39,7 +39,7 @@ let rotated: Matrix<2, 1, Distance> = rot.product(&pos).unwrap();
 
 ## 一、物理量系统
 
-19 种物理量，每种支持多种单位，物理量之间的运算在编译期进行量纲检查。
+25 种物理量，每种支持多种单位，物理量之间的运算在编译期进行量纲检查。
 
 ### 支持的物理量
 
@@ -63,6 +63,12 @@ let rotated: Matrix<2, 1, Distance> = rot.product(&pos).unwrap();
 | 磁感应强度 `MagneticInduction` | T, G, mT, μT, nT |
 | 磁矩 `MagneticMoment` | A·m², J/T |
 | 磁角速度 `MagneticAngularVelocity` | T·rad/s |
+| 电流 `ElectricCurrent` | A, mA, μA, kA |
+| 电压 `ElectricPotential` | V, mV, μV, kV |
+| 电阻 `ElectricResistance` | Ω, mΩ, kΩ, MΩ |
+| 电荷量 `ElectricCharge` | C, mC, μC, nC |
+| 电容 `ElectricCapacitance` | F, mF, μF, nF, pF |
+| 电导 `ElectricConductance` | S, mS, μS |
 | 系数 `Coef` | 无量纲 |
 
 ### 物理量运算
@@ -83,6 +89,16 @@ let energy: Energy = force * distance;             // W = F × d → 20000 J
 let angle = Angular::from_deg(180.0);
 let omega: AngularVelocity = angle / time;
 let alpha: AngularAcceleration = omega / time;
+
+// 电学（欧姆定律与功率）
+let current = ElectricCurrent::from_a(2.0);
+let resistance = ElectricResistance::from_ohm(5.0);
+let voltage: ElectricPotential = current * resistance;   // V = I × R → 10 V
+let power: Power = voltage * current;                    // P = V × I → 20 W
+
+// 电能
+let charge = ElectricCharge::from_coulomb(3.0);
+let energy2: Energy = charge * voltage;                  // E = Q × V → 30 J
 ```
 
 ---

--- a/README.en.md
+++ b/README.en.md
@@ -39,7 +39,7 @@ let rotated: Matrix<2, 1, Distance> = rot.product(&pos).unwrap();
 
 ## 1. Physical Quantity System
 
-19 physical quantities, each with multiple units. Operations between quantities are dimensionally checked at compile time.
+25 physical quantities, each with multiple units. Operations between quantities are dimensionally checked at compile time.
 
 ### Supported Quantities
 
@@ -63,6 +63,12 @@ let rotated: Matrix<2, 1, Distance> = rot.product(&pos).unwrap();
 | `MagneticInduction` | T, G, mT, μT, nT |
 | `MagneticMoment` | A·m², J/T |
 | `MagneticAngularVelocity` | T·rad/s |
+| `ElectricCurrent` | A, mA, μA, kA |
+| `ElectricPotential` | V, mV, μV, kV |
+| `ElectricResistance` | Ω, mΩ, kΩ, MΩ |
+| `ElectricCharge` | C, mC, μC, nC |
+| `ElectricCapacitance` | F, mF, μF, nF, pF |
+| `ElectricConductance` | S, mS, μS |
 | `Coef` | dimensionless |
 
 ### Quantity Arithmetic
@@ -83,6 +89,16 @@ let energy: Energy = force * distance;           // W = F × d → 20000 J
 let angle = Angular::from_deg(180.0);
 let omega: AngularVelocity = angle / dt;
 let alpha: AngularAcceleration = omega / dt;
+
+// Electricity (Ohm's law & power)
+let current = ElectricCurrent::from_a(2.0);
+let resistance = ElectricResistance::from_ohm(5.0);
+let voltage: ElectricPotential = current * resistance;   // V = I × R → 10 V
+let power: Power = voltage * current;                    // P = V × I → 20 W
+
+// Electrical energy
+let charge = ElectricCharge::from_coulomb(3.0);
+let energy2: Energy = charge * voltage;                  // E = Q × V → 30 J
 ```
 
 ---

--- a/src/physics/basic/electric_capacitance.rs
+++ b/src/physics/basic/electric_capacitance.rs
@@ -320,4 +320,51 @@ mod tests {
         a.set_value(42.0);
         assert_relative_eq!(a.as_farad(), 42.0);
     }
+
+    #[test]
+    fn test_electric_capacitance_all_as_branches() {
+        let mf = ElectricCapacitance::from_milli_farad(1.0);
+        let uf = ElectricCapacitance::from_micro_farad(1.0);
+        let nf = ElectricCapacitance::from_nano_farad(1.0);
+        let pf = ElectricCapacitance::from_pico_farad(1.0);
+
+        // as_milli_farad 非默认分支
+        assert_relative_eq!(mf.as_milli_farad(), 1.0);
+        assert_relative_eq!(uf.as_milli_farad(), 1e-3);
+        assert_relative_eq!(nf.as_milli_farad(), 1e-6);
+        assert_relative_eq!(pf.as_milli_farad(), 1e-9);
+
+        // as_micro_farad 非默认分支
+        assert_relative_eq!(mf.as_micro_farad(), 1000.0000000000001);
+        assert_relative_eq!(uf.as_micro_farad(), 1.0);
+        assert_relative_eq!(nf.as_micro_farad(), 1e-3);
+        assert_relative_eq!(pf.as_micro_farad(), 1e-6);
+
+        // as_nano_farad 非默认分支
+        assert_relative_eq!(mf.as_nano_farad(), 1e6);
+        assert_relative_eq!(uf.as_nano_farad(), 999.9999999999999);
+        assert_relative_eq!(nf.as_nano_farad(), 1.0);
+        assert_relative_eq!(pf.as_nano_farad(), 1e-3);
+
+        // as_pico_farad 非默认分支
+        assert_relative_eq!(mf.as_pico_farad(), 1e9);
+        assert_relative_eq!(uf.as_pico_farad(), 1e6);
+        assert_relative_eq!(nf.as_pico_farad(), 1000.0000000000001);
+        assert_relative_eq!(pf.as_pico_farad(), 1.0);
+    }
+
+    #[test]
+    fn test_electric_capacitance_f64_and_ref_sub() {
+        let a = ElectricCapacitance::from_farad(10.0);
+        let b = ElectricCapacitance::from_farad(3.0);
+        // Add<f64>
+        assert_relative_eq!((a + 5.0).as_farad(), 15.0);
+        // Sub<f64>
+        assert_relative_eq!((a - 5.0).as_farad(), 5.0);
+        // Sub 引用形式
+        assert_relative_eq!((a - &b).as_farad(), 7.0);
+        assert_relative_eq!((&a - b).as_farad(), 7.0);
+        // f64 / 量
+        assert_relative_eq!((100.0 / a).as_farad(), 10.0);
+    }
 }

--- a/src/physics/basic/electric_charge.rs
+++ b/src/physics/basic/electric_charge.rs
@@ -296,4 +296,41 @@ mod tests {
         a.set_value(42.0);
         assert_relative_eq!(a.as_coulomb(), 42.0);
     }
+
+    #[test]
+    fn test_electric_charge_all_as_branches() {
+        let mc = ElectricCharge::from_milli_coulomb(1.0);
+        let uc = ElectricCharge::from_micro_coulomb(1.0);
+        let nc = ElectricCharge::from_nano_coulomb(1.0);
+
+        // as_milli_coulomb 非默认分支
+        assert_relative_eq!(mc.as_milli_coulomb(), 1.0);
+        assert_relative_eq!(uc.as_milli_coulomb(), 1e-3);
+        assert_relative_eq!(nc.as_milli_coulomb(), 1e-6);
+
+        // as_micro_coulomb 非默认分支
+        assert_relative_eq!(mc.as_micro_coulomb(), 1000.0000000000001);
+        assert_relative_eq!(uc.as_micro_coulomb(), 1.0);
+        assert_relative_eq!(nc.as_micro_coulomb(), 1e-3);
+
+        // as_nano_coulomb 非默认分支
+        assert_relative_eq!(mc.as_nano_coulomb(), 1e6);
+        assert_relative_eq!(uc.as_nano_coulomb(), 999.9999999999999);
+        assert_relative_eq!(nc.as_nano_coulomb(), 1.0);
+    }
+
+    #[test]
+    fn test_electric_charge_f64_and_ref_sub() {
+        let a = ElectricCharge::from_coulomb(10.0);
+        let b = ElectricCharge::from_coulomb(3.0);
+        // Add<f64>
+        assert_relative_eq!((a + 5.0).as_coulomb(), 15.0);
+        // Sub<f64>
+        assert_relative_eq!((a - 5.0).as_coulomb(), 5.0);
+        // Sub 引用形式
+        assert_relative_eq!((a - &b).as_coulomb(), 7.0);
+        assert_relative_eq!((&a - b).as_coulomb(), 7.0);
+        // f64 / 量
+        assert_relative_eq!((100.0 / a).as_coulomb(), 10.0);
+    }
 }

--- a/src/physics/basic/electric_conductance.rs
+++ b/src/physics/basic/electric_conductance.rs
@@ -274,4 +274,33 @@ mod tests {
         a.set_value(42.0);
         assert_relative_eq!(a.as_siemens(), 42.0);
     }
+
+    #[test]
+    fn test_electric_conductance_all_as_branches() {
+        let ms = ElectricConductance::from_milli_siemens(1.0);
+        let us = ElectricConductance::from_micro_siemens(1.0);
+
+        // as_milli_siemens 非默认分支
+        assert_relative_eq!(ms.as_milli_siemens(), 1.0);
+        assert_relative_eq!(us.as_milli_siemens(), 1e-3);
+
+        // as_micro_siemens 非默认分支
+        assert_relative_eq!(ms.as_micro_siemens(), 1000.0000000000001);
+        assert_relative_eq!(us.as_micro_siemens(), 1.0);
+    }
+
+    #[test]
+    fn test_electric_conductance_f64_and_ref_sub() {
+        let a = ElectricConductance::from_siemens(10.0);
+        let b = ElectricConductance::from_siemens(3.0);
+        // Add<f64>
+        assert_relative_eq!((a + 5.0).as_siemens(), 15.0);
+        // Sub<f64>
+        assert_relative_eq!((a - 5.0).as_siemens(), 5.0);
+        // Sub 引用形式
+        assert_relative_eq!((a - &b).as_siemens(), 7.0);
+        assert_relative_eq!((&a - b).as_siemens(), 7.0);
+        // f64 / 量
+        assert_relative_eq!((100.0 / a).as_siemens(), 10.0);
+    }
 }

--- a/src/physics/basic/electric_current.rs
+++ b/src/physics/basic/electric_current.rs
@@ -351,4 +351,66 @@ mod tests {
         let result2: ElectricCurrent = r2 * l2;
         assert_relative_eq!(result2.as_a(), 6.0);
     }
+
+    #[test]
+    fn test_electric_current_all_as_branches() {
+        let ma = ElectricCurrent::from_milli_a(1.0);
+        let ua = ElectricCurrent::from_micro_a(1.0);
+        let ka = ElectricCurrent::from_kilo_a(1.0);
+
+        // as_milli_a 非默认分支
+        assert_relative_eq!(ma.as_milli_a(), 1.0);
+        assert_relative_eq!(ua.as_milli_a(), 1e-3);
+        assert_relative_eq!(ka.as_milli_a(), 1e6);
+
+        // as_micro_a 非默认分支
+        assert_relative_eq!(ma.as_micro_a(), 1000.0000000000001);
+        assert_relative_eq!(ua.as_micro_a(), 1.0);
+        assert_relative_eq!(ka.as_micro_a(), 1e9);
+
+        // as_kilo_a 非默认分支
+        assert_relative_eq!(ma.as_kilo_a(), 1e-6);
+        assert_relative_eq!(ua.as_kilo_a(), 9.999999999999999e-10);
+        assert_relative_eq!(ka.as_kilo_a(), 1.0);
+    }
+
+    #[test]
+    fn test_electric_current_f64_and_ref_sub() {
+        let a = ElectricCurrent::from_a(10.0);
+        let b = ElectricCurrent::from_a(3.0);
+        // Add<f64>
+        assert_relative_eq!((a + 5.0).as_a(), 15.0);
+        // Sub<f64>
+        assert_relative_eq!((a - 5.0).as_a(), 5.0);
+        // Sub 引用形式
+        assert_relative_eq!((a - &b).as_a(), 7.0);
+        assert_relative_eq!((&a - b).as_a(), 7.0);
+        // f64 / 量
+        assert_relative_eq!((100.0 / a).as_a(), 10.0);
+    }
+
+    #[test]
+    fn test_voltage_times_conductance_ref_forms() {
+        // V × G 引用形式
+        let v = ElectricPotential::from_v(2.0);
+        let g = ElectricConductance::from_siemens(3.0);
+        assert_relative_eq!((&v * &g).as_a(), 6.0);
+        let v2 = ElectricPotential::from_v(2.0);
+        let g2 = ElectricConductance::from_siemens(3.0);
+        assert_relative_eq!((v2 * &g2).as_a(), 6.0);
+        let v3 = ElectricPotential::from_v(2.0);
+        let g3 = ElectricConductance::from_siemens(3.0);
+        assert_relative_eq!((&v3 * g3).as_a(), 6.0);
+
+        // G × V 引用形式
+        let g4 = ElectricConductance::from_siemens(2.0);
+        let v4 = ElectricPotential::from_v(3.0);
+        assert_relative_eq!((&g4 * &v4).as_a(), 6.0);
+        let g5 = ElectricConductance::from_siemens(2.0);
+        let v5 = ElectricPotential::from_v(3.0);
+        assert_relative_eq!((g5 * &v5).as_a(), 6.0);
+        let g6 = ElectricConductance::from_siemens(2.0);
+        let v6 = ElectricPotential::from_v(3.0);
+        assert_relative_eq!((&g6 * v6).as_a(), 6.0);
+    }
 }

--- a/src/physics/basic/electric_potential.rs
+++ b/src/physics/basic/electric_potential.rs
@@ -351,4 +351,66 @@ mod tests {
         let result2: ElectricPotential = r2 * l2;
         assert_relative_eq!(result2.as_v(), 6.0);
     }
+
+    #[test]
+    fn test_electric_potential_all_as_branches() {
+        let mv = ElectricPotential::from_milli_v(1.0);
+        let uv = ElectricPotential::from_micro_v(1.0);
+        let kv = ElectricPotential::from_kilo_v(1.0);
+
+        // as_milli_v 非默认分支
+        assert_relative_eq!(mv.as_milli_v(), 1.0);
+        assert_relative_eq!(uv.as_milli_v(), 1e-3);
+        assert_relative_eq!(kv.as_milli_v(), 1e6);
+
+        // as_micro_v 非默认分支
+        assert_relative_eq!(mv.as_micro_v(), 1000.0000000000001);
+        assert_relative_eq!(uv.as_micro_v(), 1.0);
+        assert_relative_eq!(kv.as_micro_v(), 1e9);
+
+        // as_kilo_v 非默认分支
+        assert_relative_eq!(mv.as_kilo_v(), 1e-6);
+        assert_relative_eq!(uv.as_kilo_v(), 9.999999999999999e-10);
+        assert_relative_eq!(kv.as_kilo_v(), 1.0);
+    }
+
+    #[test]
+    fn test_electric_potential_f64_and_ref_sub() {
+        let a = ElectricPotential::from_v(10.0);
+        let b = ElectricPotential::from_v(3.0);
+        // Add<f64>
+        assert_relative_eq!((a + 5.0).as_v(), 15.0);
+        // Sub<f64>
+        assert_relative_eq!((a - 5.0).as_v(), 5.0);
+        // Sub 引用形式
+        assert_relative_eq!((a - &b).as_v(), 7.0);
+        assert_relative_eq!((&a - b).as_v(), 7.0);
+        // f64 / 量
+        assert_relative_eq!((100.0 / a).as_v(), 10.0);
+    }
+
+    #[test]
+    fn test_current_times_resistance_ref_forms() {
+        // I × R 引用形式
+        let i = ElectricCurrent::from_a(2.0);
+        let r = ElectricResistance::from_ohm(3.0);
+        assert_relative_eq!((&i * &r).as_v(), 6.0);
+        let i2 = ElectricCurrent::from_a(2.0);
+        let r2 = ElectricResistance::from_ohm(3.0);
+        assert_relative_eq!((i2 * &r2).as_v(), 6.0);
+        let i3 = ElectricCurrent::from_a(2.0);
+        let r3 = ElectricResistance::from_ohm(3.0);
+        assert_relative_eq!((&i3 * r3).as_v(), 6.0);
+
+        // R × I 引用形式
+        let r4 = ElectricResistance::from_ohm(2.0);
+        let i4 = ElectricCurrent::from_a(3.0);
+        assert_relative_eq!((&r4 * &i4).as_v(), 6.0);
+        let r5 = ElectricResistance::from_ohm(2.0);
+        let i5 = ElectricCurrent::from_a(3.0);
+        assert_relative_eq!((r5 * &i5).as_v(), 6.0);
+        let r6 = ElectricResistance::from_ohm(2.0);
+        let i6 = ElectricCurrent::from_a(3.0);
+        assert_relative_eq!((&r6 * i6).as_v(), 6.0);
+    }
 }

--- a/src/physics/basic/electric_resistance.rs
+++ b/src/physics/basic/electric_resistance.rs
@@ -296,4 +296,41 @@ mod tests {
         a.set_value(42.0);
         assert_relative_eq!(a.as_ohm(), 42.0);
     }
+
+    #[test]
+    fn test_electric_resistance_all_as_branches() {
+        let mo = ElectricResistance::from_mill_ohm(1.0);
+        let ko = ElectricResistance::from_kilo_ohm(1.0);
+        let mo2 = ElectricResistance::from_mega_ohm(1.0);
+
+        // as_mill_ohm 非默认分支
+        assert_relative_eq!(mo.as_mill_ohm(), 1.0);
+        assert_relative_eq!(ko.as_mill_ohm(), 1e6);
+        assert_relative_eq!(mo2.as_mill_ohm(), 1e9);
+
+        // as_kilo_ohm 非默认分支
+        assert_relative_eq!(mo.as_kilo_ohm(), 1e-6);
+        assert_relative_eq!(ko.as_kilo_ohm(), 1.0);
+        assert_relative_eq!(mo2.as_kilo_ohm(), 1e3);
+
+        // as_mega_ohm 非默认分支
+        assert_relative_eq!(mo.as_mega_ohm(), 1e-9);
+        assert_relative_eq!(ko.as_mega_ohm(), 1e-3);
+        assert_relative_eq!(mo2.as_mega_ohm(), 1.0);
+    }
+
+    #[test]
+    fn test_electric_resistance_f64_and_ref_sub() {
+        let a = ElectricResistance::from_ohm(10.0);
+        let b = ElectricResistance::from_ohm(3.0);
+        // Add<f64>
+        assert_relative_eq!((a + 5.0).as_ohm(), 15.0);
+        // Sub<f64>
+        assert_relative_eq!((a - 5.0).as_ohm(), 5.0);
+        // Sub 引用形式
+        assert_relative_eq!((a - &b).as_ohm(), 7.0);
+        assert_relative_eq!((&a - b).as_ohm(), 7.0);
+        // f64 / 量
+        assert_relative_eq!((100.0 / a).as_ohm(), 10.0);
+    }
 }

--- a/src/physics/basic/energy.rs
+++ b/src/physics/basic/energy.rs
@@ -1137,4 +1137,41 @@ mod tests {
         let neg_e5 = -e5;
         assert_relative_eq!(neg_e5.as_electron_volt(), -100.0);
     }
+
+    #[test]
+    fn test_charge_times_potential_is_energy() {
+        // Q × V（值×值）
+        let q = ElectricCharge::from_coulomb(2.0);
+        let v = ElectricPotential::from_v(3.0);
+        let e: Energy = q * v;
+        assert_relative_eq!(e.as_joule(), 6.0);
+
+        // Q × V 引用形式
+        let q2 = ElectricCharge::from_coulomb(2.0);
+        let v2 = ElectricPotential::from_v(3.0);
+        assert_relative_eq!((&q2 * &v2).as_joule(), 6.0);
+        let q3 = ElectricCharge::from_coulomb(2.0);
+        let v3 = ElectricPotential::from_v(3.0);
+        assert_relative_eq!((q3 * &v3).as_joule(), 6.0);
+        let q4 = ElectricCharge::from_coulomb(2.0);
+        let v4 = ElectricPotential::from_v(3.0);
+        assert_relative_eq!((&q4 * v4).as_joule(), 6.0);
+
+        // V × Q（值×值）
+        let v5 = ElectricPotential::from_v(2.0);
+        let q5 = ElectricCharge::from_coulomb(3.0);
+        let e5: Energy = v5 * q5;
+        assert_relative_eq!(e5.as_joule(), 6.0);
+
+        // V × Q 引用形式
+        let v6 = ElectricPotential::from_v(2.0);
+        let q6 = ElectricCharge::from_coulomb(3.0);
+        assert_relative_eq!((&v6 * &q6).as_joule(), 6.0);
+        let v7 = ElectricPotential::from_v(2.0);
+        let q7 = ElectricCharge::from_coulomb(3.0);
+        assert_relative_eq!((v7 * &q7).as_joule(), 6.0);
+        let v8 = ElectricPotential::from_v(2.0);
+        let q8 = ElectricCharge::from_coulomb(3.0);
+        assert_relative_eq!((&v8 * q8).as_joule(), 6.0);
+    }
 }

--- a/src/physics/basic/power.rs
+++ b/src/physics/basic/power.rs
@@ -1105,4 +1105,48 @@ mod tests {
         let neg_p5 = -p5;
         assert_relative_eq!(neg_p5.as_watt(), -745.7);
     }
+
+    #[test]
+    fn test_voltage_times_current_is_power() {
+        // V × I（值×值）
+        let v = ElectricPotential::from_v(2.0);
+        let i = ElectricCurrent::from_a(3.0);
+        let p: Power = v * i;
+        assert_relative_eq!(p.as_watt(), 6.0);
+
+        // V × I 引用形式
+        let v2 = ElectricPotential::from_v(2.0);
+        let i2 = ElectricCurrent::from_a(3.0);
+        assert_relative_eq!((&v2 * &i2).as_watt(), 6.0);
+        let v3 = ElectricPotential::from_v(2.0);
+        let i3 = ElectricCurrent::from_a(3.0);
+        assert_relative_eq!((v3 * &i3).as_watt(), 6.0);
+        let v4 = ElectricPotential::from_v(2.0);
+        let i4 = ElectricCurrent::from_a(3.0);
+        assert_relative_eq!((&v4 * i4).as_watt(), 6.0);
+
+        // I × V（值×值）
+        let i5 = ElectricCurrent::from_a(2.0);
+        let v5 = ElectricPotential::from_v(3.0);
+        let p5: Power = i5 * v5;
+        assert_relative_eq!(p5.as_watt(), 6.0);
+
+        // I × V 引用形式
+        let i6 = ElectricCurrent::from_a(2.0);
+        let v6 = ElectricPotential::from_v(3.0);
+        assert_relative_eq!((&i6 * &v6).as_watt(), 6.0);
+        let i7 = ElectricCurrent::from_a(2.0);
+        let v7 = ElectricPotential::from_v(3.0);
+        assert_relative_eq!((i7 * &v7).as_watt(), 6.0);
+        let i8 = ElectricCurrent::from_a(2.0);
+        let v8 = ElectricPotential::from_v(3.0);
+        assert_relative_eq!((&i8 * v8).as_watt(), 6.0);
+    }
+
+    #[test]
+    fn test_power_as_any() {
+        let g: &dyn PhysicalQuantity = &Power::from_watt(1.23);
+        let d = g.as_any().downcast_ref::<Power>().unwrap();
+        assert_relative_eq!(d.as_watt(), 1.23);
+    }
 }


### PR DESCRIPTION
## 修复增量覆盖率

PR #47 合并后 Codecov 增量覆盖率只有 85.16%（176 行缺失），本次补全到 100%。

### 缺失原因
- `energy.rs` / `power.rs` 的跨类型乘法（Q×V=Energy、V×I=Power）8 个 impl 完全没有测试
- 6 个电学量文件的 `as_xxx` 非默认单位分支、`Add/Sub<f64>`、`Sub` 引用形式、`f64/量` 未覆盖

### 修复内容
- 新增 17 个测试，覆盖所有缺失行
- `energy.rs`：Q×V、V×Q 共 8 个 impl
- `power.rs`：V×I、I×V 共 8 个 impl + `as_any`
- 6 个电学量文件：单位转换分支 + 标量运算符（`Add/Sub<f64>`、`f64/量`、引用减法）
- `.gitignore` 增加 `.workbuddy/`

测试：905 全绿（885 单元 + 20 doc-test）。
覆盖率：8 个相关文件全部 100%。
